### PR TITLE
chore(deps): update flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1745565707,
-        "narHash": "sha256-ccFeWWQ9RLgCd1k+xwV/ASUkJ7AGTTaGDhlRWZgytxY=",
+        "lastModified": 1751399845,
+        "narHash": "sha256-iun7//YHeEFgEOcG4KKKoy3d2GWOYqokLFVU/zIs79Y=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "ed504db425c363b13f13d5ca52f1a2600c4a7703",
+        "rev": "e24a50ff9b5871d4bdd8900679784812eeb120ea",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746461020,
-        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
         "type": "github"
       },
       "original": {
@@ -66,11 +66,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1746683680,
-        "narHash": "sha256-+5zk+UbG0+GQlKt+gIKm+OhlYvHmkAHFXvf7hl1HDeM=",
+        "lastModified": 1751829618,
+        "narHash": "sha256-VaJnqOkhDfEUXYZpbEuiSUTJnemjGJChIQOD9fjMl/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16762245d811fdd74b417cc922223dc8eb741e8b",
+        "rev": "fa50093d3bb32dcfaaa689a3e89cdf4702c95365",
         "type": "github"
       },
       "original": {
@@ -82,11 +82,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1740324671,
-        "narHash": "sha256-djc+wRG9L70jlW95Ck4GKr7nTPp1drfsXshJkYZAd9s=",
+        "lastModified": 1749418557,
+        "narHash": "sha256-wJHHckWz4Gvj8HXtM5WVJzSKXAEPvskQANVoRiu2w1w=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "2a17e49b8a5d32278ed77e4a881f992472be18a1",
+        "rev": "91dcc48a6298e47e2441ec76df711f4e38eab94e",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1746514387,
-        "narHash": "sha256-f6B1SS7F1EVHOifkE7qwv8Q6LrNwtB8qRavcMQfqLVU=",
+        "lastModified": 1751762497,
+        "narHash": "sha256-GD9n0vKsepwk93i3k6qDskIsaL7Cg5YYgHwdsMfmb2E=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "5ae35569c2594dee7be5be343561fb130941be67",
+        "rev": "0577b791952b95184770628aae38ce82e2a89223",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR was generated automatically to update the flake inputs.

<details>
<summary>Flake update summary (from commit message)</summary>

```console
warning: updating lock file '"/tmp/gh-flake-update.9oJ8SV5Lhz/worktree/flake.lock"':
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/c621e8422220273271f52058f618c94e405bb0f5?narHash=sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY%3D' (2025-04-01)
  → 'github:hercules-ci/flake-parts/77826244401ea9de6e3bac47c2db46005e1f30b5?narHash=sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ%3D' (2025-07-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:nix-community/nixpkgs.lib/e4822aea2a6d1cdd36653c134cacfd64c97ff4fa?narHash=sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc%3D' (2025-03-30)
  → 'github:nix-community/nixpkgs.lib/14a40a1d7fb9afa4739275ac642ed7301a9ba1ab?narHash=sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo%3D' (2025-06-29)
• Updated input 'import-tree':
    'github:vic/import-tree/ed504db425c363b13f13d5ca52f1a2600c4a7703?narHash=sha256-ccFeWWQ9RLgCd1k%2BxwV/ASUkJ7AGTTaGDhlRWZgytxY%3D' (2025-04-25)
  → 'github:vic/import-tree/e24a50ff9b5871d4bdd8900679784812eeb120ea?narHash=sha256-iun7//YHeEFgEOcG4KKKoy3d2GWOYqokLFVU/zIs79Y%3D' (2025-07-01)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3730d8a308f94996a9ba7c7138ede69c1b9ac4ae?narHash=sha256-7%2BpG1I9jvxNlmln4YgnlW4o%2Bw0TZX24k688mibiFDUE%3D' (2025-05-05)
  → 'github:nixos/nixpkgs/5c724ed1388e53cc231ed98330a60eb2f7be4be3?narHash=sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8%2B%2BxWA8itO4%3D' (2025-07-04)
• Updated input 'nixpkgs-master':
    'github:nixos/nixpkgs/16762245d811fdd74b417cc922223dc8eb741e8b?narHash=sha256-%2B5zk%2BUbG0%2BGQlKt%2BgIKm%2BOhlYvHmkAHFXvf7hl1HDeM%3D' (2025-05-08)
  → 'github:nixos/nixpkgs/fa50093d3bb32dcfaaa689a3e89cdf4702c95365?narHash=sha256-VaJnqOkhDfEUXYZpbEuiSUTJnemjGJChIQOD9fjMl/U%3D' (2025-07-06)
• Updated input 'process-compose-flake':
    'github:Platonic-Systems/process-compose-flake/2a17e49b8a5d32278ed77e4a881f992472be18a1?narHash=sha256-djc%2BwRG9L70jlW95Ck4GKr7nTPp1drfsXshJkYZAd9s%3D' (2025-02-23)
  → 'github:Platonic-Systems/process-compose-flake/91dcc48a6298e47e2441ec76df711f4e38eab94e?narHash=sha256-wJHHckWz4Gvj8HXtM5WVJzSKXAEPvskQANVoRiu2w1w%3D' (2025-06-08)
• Updated input 'services-flake':
    'github:juspay/services-flake/5ae35569c2594dee7be5be343561fb130941be67?narHash=sha256-f6B1SS7F1EVHOifkE7qwv8Q6LrNwtB8qRavcMQfqLVU%3D' (2025-05-06)
  → 'github:juspay/services-flake/0577b791952b95184770628aae38ce82e2a89223?narHash=sha256-GD9n0vKsepwk93i3k6qDskIsaL7Cg5YYgHwdsMfmb2E%3D' (2025-07-06)
```

</details>

<details>
<summary>Attribute: <code>packages.x86_64-linux.default</code> (Build Failed)</summary>

```console
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'ai-services'
         whose name attribute is located at /nix/store/cd7fkv2r1nflz758r8bsnqfvkq7f72wj-source/pkgs/stdenv/generic/make-derivation.nix:468:13

       … while evaluating attribute 'text' of derivation 'ai-services'
         at /nix/store/cd7fkv2r1nflz758r8bsnqfvkq7f72wj-source/pkgs/build-support/trivial-builders/default.nix:129:13:
          128|           inherit
          129|             text
             |             ^
          130|             executable

       … while evaluating the option `perSystem.x86_64-linux.process-compose.ai-services.outputs.settingsFile':

       … while evaluating definitions from `/nix/store/rs6a9x7h07k5zmg6nfp47v62c12qni74-source/nix/process-compose/settings':

       … while evaluating the option `perSystem.x86_64-linux.process-compose.ai-services.settings.processes.open-webui1.command':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Package ‘open-webui-0.6.15’ in /nix/store/cd7fkv2r1nflz758r8bsnqfvkq7f72wj-source/pkgs/by-name/op/open-webui/package.nix:216 has an unfree license (‘unknown’), refusing to evaluate.

       a) To temporarily allow unfree packages, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNFREE=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnfree = true; }
       in configuration.nix to override this.

       Alternatively you can configure a predicate to allow specific packages:
         { nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
             "open-webui"
           ];
         }

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnfree = true; }
       to ~/.config/nixpkgs/config.nix.
```

</details>
